### PR TITLE
Add coordinate validation based on team

### DIFF
--- a/pyatmo/kmz_generator_class.py
+++ b/pyatmo/kmz_generator_class.py
@@ -151,11 +151,20 @@ class KMZGenerator:
             models = [model for model, var in self.model_vars.items() if var.get()]
             n_points = int(self.points_var.get())
             team = self.team_var.get()
+
+            # Validate coordinates based on team
+            if team == "SIROCCO":
+                if not (-90 <= lat <= 90) or not (-180 <= lon <= 180):
+                    raise ValueError("Coordinates out of range for team SIROCCO")
+            elif team == "NEBBO":
+                if not (-90 <= lat <= 90) or not (0 <= lon <= 360):
+                    raise ValueError("Coordinates out of range for team NEBBO")
+
             logger.info(f"Input values: asset_name={asset_name}, lat={lat}, lon={lon}, models={models}, n_points={n_points}, team={team}")
             return asset_name, lat, lon, models, n_points, team
-        except ValueError:
-            logger.error("Invalid input values for latitude, longitude, or number of points")
-            messagebox.showerror('Error', 'Introduce valores válidos para latitud, longitud y número de puntos.')
+        except ValueError as e:
+            logger.error(f"Invalid input values: {e}")
+            messagebox.showerror('Error', f'Introduce valores válidos para latitud, longitud y número de puntos. {e}')
             return None, None, None, None, None, None
 
     def _generate_file(self, file_type, create_function):

--- a/pyatmo/map_points.py
+++ b/pyatmo/map_points.py
@@ -288,4 +288,3 @@ def create_map_kml(
     MapGenerator(team).create_map_kml(
         latitude, longitude, n_points, filename, path_file, models
     )
-


### PR DESCRIPTION
Add validation for latitude and longitude based on the selected team in `_get_input_values` method in `pyatmo/kmz_generator_class.py`.

* Validate coordinates for team "SIROCCO" to be within latitude -90 to 90 and longitude -180 to 180.
* Validate coordinates for team "NEBBO" to be within latitude -90 to 90 and longitude 0 to 360.
* Show error message and prompt user to re-enter coordinates if they are out of range.

Remove unnecessary blank line in `pyatmo/map_points.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LuisTellezSirocco/GeoAtmoPlot?shareId=50e4783f-311f-466c-9cbf-72808bce38bf).