### PR TITLE
Add ICON model for SIROCCO team

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ The core functionality of the application is implemented in the [`kmz_generator.
 
 6. **Save file**: Choose a location on your computer to save the generated file.
 
+## Supported Models
+
+The application supports the following meteorological models:
+
+- ECMWF
+- GFS_0.5
+- GFS_0.25
+- UKMET
+- NCEP
+- DWD
+- METEOFRANCE
+- CMCC
+- JMA
+- ICON
+
 ## Advantages
 
 1. **Multiple models**: Allows you to compare grid points from various global meteorological models on a single map.

--- a/pyatmo/kmz_generator_class.py
+++ b/pyatmo/kmz_generator_class.py
@@ -119,7 +119,7 @@ class KMZGenerator:
     def _get_models_for_team(self, team):
         logger.info(f"Getting models for team: {team}")
         if team == "SIROCCO":
-            return ["ECMWF", "GFS_0.5", "GFS_0.25", "UKMET", "NCEP", "DWD", "METEOFRANCE", "CMCC", "JMA"]
+            return ["ECMWF", "GFS_0.5", "GFS_0.25", "UKMET", "NCEP", "DWD", "METEOFRANCE", "CMCC", "JMA", "ICON"]
         elif team == "NEBBO":
             return ["ECMWF", "GFS_0.5", "GFS_0.25", "UKMET", "NCEP", "DWD", "METEOFRANCE", "CMCC", "JMA", "ECCC"]  # Añadir más modelos si es necesario
 

--- a/pyatmo/map_points.py
+++ b/pyatmo/map_points.py
@@ -67,6 +67,7 @@ class MapGenerator:
                 "METEOFRANCE": GridPointSelector((-90.0, 90.0), (-180.0, 180.0), 0.1),
                 "CMCC": GridPointSelector((-90.0, 90.0), (-180.0, 180.0), 0.25),
                 "JMA": GridPointSelector((-90.0, 90.0), (-180.0, 180.0), 0.2),
+                "ICON": GridPointSelector((29.5, 70.5), (336.5, 62.5), 0.0625),
                 **common_models,
             }
         elif self.team == "NEBBO":
@@ -222,6 +223,7 @@ class MapGenerator:
             "METEOFRANCE": "darkred",
             "CMCC": "darkgreen",
             "JMA": "darkblue",
+            "ICON": "purple",
             "COMMON": "cadetblue",
             "OBJECTIVE": "black",
         }


### PR DESCRIPTION
Add ICON model for SIROCCO team

* Add ICON model to the `MapGenerator` class in `pyatmo/map_points.py`
  - Define grid parameters for the ICON model
  - Update `_update_model_selectors` method to include the ICON model
* Add ICON model to the list of models for the SIROCCO team in `pyatmo/kmz_generator_class.py`
* Mention ICON model as one of the supported models in `README.md`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LuisTellezSirocco/GeoAtmoPlot?shareId=35b6654b-44b4-401d-9f3d-777bc638c8d4).